### PR TITLE
fix: certificate download issue fixed

### DIFF
--- a/robinhood/robinhood/doctype/certificate/certificate.js
+++ b/robinhood/robinhood/doctype/certificate/certificate.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, zerodha and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Certificate', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/robinhood/robinhood/doctype/certificate/certificate.json
+++ b/robinhood/robinhood/doctype/certificate/certificate.json
@@ -1,0 +1,61 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:certificate_name",
+ "creation": "2022-12-23 11:06:16.736774",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "number_of_checkins",
+  "certificate_name",
+  "html"
+ ],
+ "fields": [
+  {
+   "fieldname": "number_of_checkins",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Number of checkins"
+  },
+  {
+   "fieldname": "certificate_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Certificate Name",
+   "unique": 1
+  },
+  {
+   "fieldname": "html",
+   "fieldtype": "HTML Editor",
+   "ignore_xss_filter": 1,
+   "label": "HTML"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-12-23 11:54:43.503956",
+ "modified_by": "Administrator",
+ "module": "Robinhood",
+ "name": "Certificate",
+ "name_case": "Title Case",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/robinhood/robinhood/doctype/certificate/certificate.py
+++ b/robinhood/robinhood/doctype/certificate/certificate.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, zerodha and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class Certificate(Document):
+	pass

--- a/robinhood/robinhood/doctype/certificate/test_certificate.py
+++ b/robinhood/robinhood/doctype/certificate/test_certificate.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, zerodha and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestCertificate(FrappeTestCase):
+	pass

--- a/robinhood/robinhood/doctype/checkin/certificate/gladiator.html
+++ b/robinhood/robinhood/doctype/checkin/certificate/gladiator.html
@@ -1,90 +1,75 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
 
+<head>
     <style>
-      @font-face {
+    @font-face {
         font-family: "myriad-pro";
         src: url("{{base_url}}/assets/robinhood/fonts/myriad_pro_regular.ttf");
         /* src: url("/Users/nikhilponnuru/frappe/v-13/apps/robinhood/robinhood/public/fonts/myriad_pro_regular.ttf"); */
         font-weight: "bold";
-      }
-      * {
-        font-family: "myriad-pro";
-      }
+    }
 
+    * {
+        font-family: "myriad-pro";
+    }
     </style>
-  </head>
-  <body style="height:1020px;margin: 0; padding: 0;display:flex;flex:1">
-    <div
-        style="
+</head>
+
+<body style="height:1020px;margin: 0; padding: 0;display:flex;flex:1">
+    <div style="
         display: -webkit-box;
         display: flex;
         flex: 1;
         -webkit-flex: 1;
         -webkit-box-flex: 1;
         position: absolute; top: 0; left: 0; height: 100%; width: 100%;
-      "
-    >
-        <div
-        style="
+      ">
+        <div style="
             width:37%;
             display: flex;
-        "
-        >
-        <img
-          src="{{base_url}}/assets/robinhood/images/gladiator.png"
-          style="position: absolute; width: 720px; height:101%;top: -10px; left: 0;bottom:0;right:0"
-        />
-
-
+        ">
+            <img src="{{base_url}}/assets/robinhood/images/gladiator.png" style="position: absolute; width: 720px; height:101%;top: -10px; left: 0;bottom:0;right:0" />
         </div>
-
         <div style="width:63%;padding-top:10px">
-        <div style="margin-left: 230px">
-          <div>
-            <p style="font-size: 50px">Congratulations</p>
-            <p style="font-size: 75px; margin-top: -24px; font-weight: bold">
-              {{robin_name}}
-            </p>
-            <p style="color: #666666; font-size: 38px; margin-top: -35px">
-              From {{robin_location}}
-            </p>
-          </div>
-          <div style="margin-top: 45px">
-            <p style="font-size: 50px">on completing</p>
-            <p
-              style="
+            <div style="margin-left: 230px">
+                <div>
+                    <p style="font-size: 50px">Congratulations</p>
+                    <p style="font-size: 75px; margin-top: -24px; font-weight: bold">
+                        {{robin_name}}
+                    </p>
+                    <p style="color: #666666; font-size: 38px; margin-top: -35px">
+                        From {{robin_location}}
+                    </p>
+                </div>
+                <div style="margin-top: 45px">
+                    <p style="font-size: 50px">on completing</p>
+                    <p style="
                 font-size: 75px;
                 font-weight: bold;
                 margin-top: -28px;
                 font-weight: bold;
-              "
-            >
-              50 food drives
-            </p>
-          </div>
-        </div>
-        <hr
-          style="
+              ">
+                        50 food drives
+                    </p>
+                </div>
+            </div>
+            <hr style="
             background-color: #165f30;
             margin-top: 135px;
             height:2px
-          "
-        />
-        <div style="margin-left: 230px; padding-top: 20px">
-          <p style="font-size: 38px; color: #222222">Issued on</p>
-          <p style="font-size: 50px; font-weight: bold; margin-top: -16px">
-            {{certificate_date}}
-          </p>
-           <p style="font-size: 22px; color: #666666; margin-top: -16px">
-            {{certificate_id}}
-          </p>
+          " />
+            <div style="margin-left: 230px; padding-top: 20px">
+                <p style="font-size: 38px; color: #222222">Issued on</p>
+                <p style="font-size: 50px; font-weight: bold; margin-top: -16px">
+                    {{certificate_date}}
+                </p>
+                <p style="font-size: 22px; color: #666666; margin-top: -16px">
+                    {{certificate_id}}
+                </p>
+            </div>
         </div>
-      </div>
     </div>
+</body>
 
-        </div>
-    </div>
-  </body>
 </html>

--- a/robinhood/robinhood/doctype/robin_certificate_log/robin_certificate_log.json
+++ b/robinhood/robinhood/doctype/robin_certificate_log/robin_certificate_log.json
@@ -22,7 +22,7 @@
    "fieldname": "type_of_certificate",
    "fieldtype": "Select",
    "label": "Type of certificate",
-   "options": "10\n50\n100"
+   "options": "\n1\n10\n50\n100"
   },
   {
    "fieldname": "certificate_id",
@@ -39,7 +39,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-02-28 11:01:00.535626",
+ "modified": "2022-12-23 14:26:29.644121",
  "modified_by": "Administrator",
  "module": "Robinhood",
  "name": "Robin Certificate Log",


### PR DESCRIPTION
Add this download method inside the script of the web page and delete the current download method from the web template.

also, add `onclick='download(1)'` to the badge image tag to download specific types of certificate
```
function download(certificate_type){
        frappe.call({
            type: 'GET',
            args: {"certificate_type": certificate_type},
            method: "robinhood.robinhood.doctype.robin_certificate_log.robin_certificate_log.download_certificate",
            callback: function(r) {
    
                frappe.show_alert({"message": "downloaded", "indicator": "green"})
                }
            })
        }
```